### PR TITLE
Feature/fix parent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-annotation",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-annotation",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^5.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-annotation",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Lint rules to validate and auto-correct annotation-based policies",
   "main": "dist/index.js",
   "scripts": {

--- a/src/rules/sort.ts
+++ b/src/rules/sort.ts
@@ -51,8 +51,8 @@ export default createRule<Options, MessageIds>({
 
         if (needSort) {
           const diffRanges = ArrayUtils.zip2(node.elements, sortedElements).map(([from, to]) => ({
-            from: from.range,
-            to: to.range,
+            from: from!.range,
+            to: to!.range,
           }))
 
           const fixedText = FixUtils.getFixedText(sourceCode, node.range, diffRanges)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "ES2016",
     "module": "commonjs",
     "moduleResolution": "Node",
-    "removeComments": true
+    "removeComments": true,
+    "strict": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
https://github.com/ronparkdev/eslint-plugin-annotation/blob/620a94f11fa9e4e6a348598aedd8056b49007c3f/src/rules/sort-keys.ts#L34-L37

Fix issue where config becomes null when no annotation is present and null execution occurs on line 35
* Added type check with typescript strict mode setting.
* Fixed some codes for type mismatching.